### PR TITLE
Fix GitHub URL for the `mmhash3` package in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     license="License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     author="Hajime Senuma",
     author_email="hajime.senuma@gmail.com",
-    url="https://github.com/Fokko/mmhash",
+    url="https://github.com/Fokko/mmhash3",
     ext_modules=[mmh3module],
     keywords="utility hash MurmurHash",
     long_description=open("README.md").read(),


### PR DESCRIPTION
I tried to find the source code from the package on PyPI, and realized that the link was broken. :)